### PR TITLE
Fix refresh tracking in LoadableMap and CachedLoadableMap

### DIFF
--- a/tests/CachedLoadableMap.test.ts
+++ b/tests/CachedLoadableMap.test.ts
@@ -28,10 +28,10 @@ describe("CachedLoadableMap", () => {
         expect(mockLoadOneFunction).toHaveBeenCalledWith("key1")
         expect(item._id).toBe("key1")
         expect(item.data).toBe("Data for key1")
-        expect(item).toHaveProperty("refreshed_at")
 
-        expect(cachedLoadableMap["expiryCache"].has("key1")).toBeTruthy()
-        expect(cachedLoadableMap["expiryCache"].get("key1")?.expiry).toBeGreaterThan(Date.now())
+        const refreshedAt = cachedLoadableMap.getRefreshedAt("key1")
+        expect(refreshedAt).toBeInstanceOf(Date)
+        expect(cachedLoadableMap["refreshedAtMap"]["key1"]).toEqual(refreshedAt)
     })
 
     test("should call loadOne function again if item is expired", async () => {
@@ -47,8 +47,8 @@ describe("CachedLoadableMap", () => {
         const items = await cachedLoadableMap.getAll()
         expect(mockLoadAllFunction).toHaveBeenCalled()
         expect(items?.size).toBe(2)
-        expect(cachedLoadableMap["expiryCache"].get("key1")?.expiry).toBeGreaterThan(Date.now())
-        expect(cachedLoadableMap["expiryCache"].get("key2")?.expiry).toBeGreaterThan(Date.now())
+        expect(cachedLoadableMap["refreshedAtMap"]["key1"]).toBeInstanceOf(Date)
+        expect(cachedLoadableMap["refreshedAtMap"]["key2"]).toBeInstanceOf(Date)
     })
 
     // Additional tests can be added as needed

--- a/tests/LoadableMap.test.ts
+++ b/tests/LoadableMap.test.ts
@@ -27,7 +27,6 @@ describe("LoadableMap", () => {
 
         expect(item._id).toBe("key1")
         expect(item.data).toBe("Data for key1")
-        expect(item).toHaveProperty("refreshed_at")
 
         expect(loadableMap["_map"].has("key1")).toBeTruthy()
     })
@@ -52,11 +51,22 @@ describe("LoadableMap", () => {
 
         expect(item1?._id).toBe("key1")
         expect(item1?.data).toBe("value1")
-        expect(item1).toHaveProperty("refreshed_at")
 
         expect(item2?._id).toBe("key2")
         expect(item2?.data).toBe("value2")
-        expect(item2).toHaveProperty("refreshed_at")
 
+    })
+
+    test("should retrieve refreshedAt time for a key", async () => {
+        await loadableMap.get("key1")
+        const refreshedAt = loadableMap.getRefreshedAt("key1")
+        expect(refreshedAt).toBeInstanceOf(Date)
+    })
+
+    test("should update refreshedAtMap for refresh times", async () => {
+        await loadableMap.get("key1")
+        const refreshedAt = loadableMap.getRefreshedAt("key1")
+        expect(refreshedAt).toBeInstanceOf(Date)
+        expect(loadableMap["refreshedAtMap"]["key1"]).toEqual(refreshedAt)
     })
 })


### PR DESCRIPTION
Remove `refreshed_at` property from `LoadableMap` and `CachedLoadableMap` classes and add `refreshedAtMap` to track refresh times separately.

* **LoadableMap.ts**
  - Remove `refreshed_at` property from `LoadableMap` class.
  - Add `refreshedAtMap` property to track refresh times separately.
  - Update `set`, `clear`, `delete`, `deleteBy`, and `processLoadResult` methods to use `refreshedAtMap`.
  - Add `getRefreshedAt` method to retrieve refresh times.

* **CachedLoadableMap.ts**
  - Remove `expiryCache` property and related logic.
  - Update `CachedLoadableMap` class to use `refreshedAtMap` from `LoadableMap`.
  - Update `get`, `getBy`, `getAll`, `delete`, and `deleteBy` methods to use `refreshedAtMap`.

* **LoadableMap.test.ts**
  - Remove checks for `refreshed_at` property.
  - Add tests for `getRefreshedAt` method.
  - Update tests to check `refreshedAtMap` for refresh times.

* **CachedLoadableMap.test.ts**
  - Remove checks for `expiryCache` property.
  - Update tests to check `refreshedAtMap` for refresh times.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/L422Y/megamap/pull/3?shareId=7121fec5-3fef-442d-899c-a0037c41f97a).